### PR TITLE
Meilleure utilisation du logger dans l'I2C et le LCD

### DIFF
--- a/utils/src/main/java/esialrobotik/ia/utils/communication/raspberry/I2C.java
+++ b/utils/src/main/java/esialrobotik/ia/utils/communication/raspberry/I2C.java
@@ -38,13 +38,14 @@ public class I2C {
      */
     public I2C(int deviceAddress) {
         logger = LoggerFactory.getLogger(I2C.class);
+        this.deviceAddress = deviceAddress;
 
         try {
-            logger.info("I2C " + deviceAddress + " init");
+            logger.info(String.format("I2C 0x%02X init", deviceAddress));
             I2CBus i2c = I2CFactory.getInstance(I2CBus.BUS_1);
             i2CDevice = i2c.getDevice(deviceAddress);
         } catch (I2CFactory.UnsupportedBusNumberException | IOException e) {
-            logger.error("I2C " + deviceAddress + " init fail : " + e.getMessage());
+            logger.error(String.format("I2C 0x%02X init fail : " + e.getMessage(), deviceAddress));
         }
     }
 
@@ -53,15 +54,7 @@ public class I2C {
      * @param deviceAddress Adresse du device (ex : 0x39)
      */
     public I2C(byte deviceAddress) {
-        logger = LoggerFactory.getLogger(I2C.class);
-
-        try {
-            logger.info("I2C " + deviceAddress + " init");
-            I2CBus i2c = I2CFactory.getInstance(I2CBus.BUS_1);
-            i2CDevice = i2c.getDevice(deviceAddress);
-        } catch (I2CFactory.UnsupportedBusNumberException | IOException e) {
-            logger.error("I2C " + deviceAddress + " init fail : " + e.getMessage());
-        }
+        this((int) deviceAddress);
     }
 
     /**
@@ -71,29 +64,33 @@ public class I2C {
      */
     public int read(byte register) {
         try {
-            logger.info("I2C " + deviceAddress + " read register " + register);
+            logger.trace(String.format("I2C 0x%02X read register 0x%02X", deviceAddress, register));
             return i2CDevice.read(register);
         } catch (IOException e) {
-            logger.error("I2C " + deviceAddress + " read register " + register + " fail : " + e.getMessage());
+            logger.error(String.format("I2C 0x%02X read register 0x%02X fail : " + e.getMessage(),
+                    deviceAddress, register));
             return 0;
         }
     }
 
     public void write(byte register, byte value) {
         try {
-            logger.info("I2C " + deviceAddress + " write register " + register + " with value " + value);
+            logger.trace(String.format("I2C 0x%02X write register 0x%02X with value 0x%02X",
+                    deviceAddress, register , value));
             i2CDevice.write(register, value);
         } catch (IOException e) {
-            logger.info("I2C " + deviceAddress + " write register " + register + " with value " + value + " fail : " + e.getMessage());
+            logger.error(String.format("I2C 0x%02X write register 0x%02X with value 0x%02X fail : " + e.getMessage(),
+                    deviceAddress, register , value));
         }
     }
 
     public void write(byte value) {
         try {
-            logger.info("I2C " + deviceAddress + " write value " + value);
+            logger.trace(String.format("I2C 0x%02X write value 0x%02X", deviceAddress, value));
             i2CDevice.write(value);
         } catch (IOException e) {
-            logger.info("I2C " + deviceAddress + " write value " + value + " fail : " + e.getMessage());
+            logger.error(String.format("I2C 0x%02X write value 0x%02X fail : " + e.getMessage(),
+                    deviceAddress, value));
         }
     }
 

--- a/utils/src/main/java/esialrobotik/ia/utils/lcd/raspberry/LCD_I2C.java
+++ b/utils/src/main/java/esialrobotik/ia/utils/lcd/raspberry/LCD_I2C.java
@@ -1,7 +1,13 @@
 package esialrobotik.ia.utils.lcd.raspberry;
 
+import java.util.Scanner;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+
 import esialrobotik.ia.utils.communication.raspberry.I2C;
 import esialrobotik.ia.utils.lcd.LCD;
+import esialrobotik.ia.utils.log.LoggerFactory;
 
 /**
  * LCD 2 lignes / 16 colonnes de Joy-It
@@ -10,6 +16,7 @@ import esialrobotik.ia.utils.lcd.LCD;
 public class LCD_I2C implements LCD {
 
     private I2C i2cDevice;
+    private Logger logger;
 
     // Default address and line counts
     private static final int DEFAULT_I2C_ADDRESS  = 0x27;
@@ -77,6 +84,9 @@ public class LCD_I2C implements LCD {
 	    throw new ArrayIndexOutOfBoundsException();
 	}
 
+	this.logger = LoggerFactory.getLogger(LCD_I2C.class);
+	logger.info("Initializing " + lineLength + "x"+ lineCount + " LCD "
+		+ "on I2C address " + String.format("0x%X", i2cAddress));
 	this.lines = new String[lineCount];
 	this.lineLength = lineLength;
 	this.i2cDevice = new I2C(i2cAddress);
@@ -130,7 +140,8 @@ public class LCD_I2C implements LCD {
 
 	for(int i = 0; i < lines.length; i++) {
 	    if(lines[i] != null) {
-		System.out.println("Will write " + lines[i]);
+		logger.info("Will display '" + lines[i] + "' on line " + (i+1));
+
 		i2cWrite(LINE_ADDR[i]);
 		byte[] strBytes = lines[i].getBytes();
 		for(int j = 0; j < strBytes.length; j++) {
@@ -168,9 +179,16 @@ public class LCD_I2C implements LCD {
 
 
     public static void main(String args[]) {
+        LoggerFactory.init(Level.INFO);
+
         LCD screen = new LCD_I2C();
         screen.println("Coucou");
         screen.println("Youpi !!!");
+        Scanner sysin = new Scanner(System.in);
+
+        while(true) {
+            screen.println(sysin.nextLine());
+        }
     }
 
 }


### PR DESCRIPTION
On évite de faire des println() alors que le logger est la pour ça
On arrete aussi de logger des trucs qui sont du niveau TRACE dans l'I2C